### PR TITLE
Add LoRA diverse-emoji.safetensors

### DIFF
--- a/lora/README.md
+++ b/lora/README.md
@@ -18,6 +18,7 @@ List of metadata for all Genmoji LoRAs.
 | LoRA Name              | Model Trained | Emojis Used                   | More Info                    |
 | ---------------------- | ------------- | ----------------------------- | ---------------------------- |
 | `flux-dev.safetensors` | Flux.1 Dev    | No Skintone Emoji List (1901) | [View](#flux-devsafetensors) |
+| [`diverse-emoji.safetensors`](https://huggingface.co/caspersimon/Diverse-Emoji/) | Flux.1 Dev    | Complete Apple Emoji list (3770) | [View](#diverse-emojisafetensors) |
 
 # Contributing a LoRA
 
@@ -36,3 +37,16 @@ Feel free to create your own LoRAs, and they can be added here if you want! Refe
 **Finetuning Steps**: 10,000
 **Image Resolution**: 160x160
 **Emoji Dataset**: All Apple Emojis as of December 25, 2024, with skin tone variants pruned to reduce training time.
+
+## `diverse-emoji.safetensors`
+
+**Model Finetuned**: Flux.1 Dev
+**Finished Finetuning**: December 31, 2024
+**Finetuned By**: Julius ([@caspersimon](https://github.com/caspersimon))
+**Finetuned On**: M4 Max MacBook Pro (128GB Unified Memory, 40 core GPU)
+**Finetuned With**: [SimpleTuner](https://github.com/bghira/SimpleTuner)
+**Finetuning Time**: ~20 hours
+**Finetuning Steps**: 20,000
+**Image Resolution**: 160x160
+**Emoji Dataset**: All Apple Emoji as of December 30, 2024.
+[**Huggingface link**](https://huggingface.co/caspersimon/Diverse-Emoji)


### PR DESCRIPTION
Watching your video on youtube inspired me to fine-tune a model so that it is able to generate emoji skin tone variations! Thank you for all example code and explanations in this repo. It made it very easy to fine-tune the model myself.

I used the complete Apple emoji set (including all skin tone variations) to fine-tune the flux.1 dev model. I used 20.000 finetuning steps, which seems to be enough.

I have already uploaded the file to huggingface ([link](https://huggingface.co/caspersimon/Diverse-Emoji)). 

Would it be an idea to create a collection in huggingface where you add EvanZhouDev/open-genmoji, caspersimon/Diverse-Emoji (the one I fine-tuned), and future contributions? This way, contributors can keep the files on their own profiles, and your repo and the collection on huggingface can be a central place where one can easily find links to the different LoRA's. Maybe this was already your plan! I'm just not sure what you mean by "I will sync it to HuggingFace" (line 25 in this README). 

If you need any more information about the LoRA or if I should change anything, please let me know!